### PR TITLE
Resolving dependencies to htmlwidgets 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Maintainer: Kenton Russell <kent.russell@timelyportfolio.com>
 Description: Provides easy access to the dimple d3.js plotting library in the form
                 of an htmlwidget.
 Depends: R (>= 3.1.2),
-    htmlwidgets
+    htmlwidgets,
+    htmltools
 License: MIT + file LICENSE
 LazyData: true
 Suggests: knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Provides easy access to the dimple d3.js plotting library in the fo
 Depends: R (>= 3.1.2)
 License: MIT + file LICENSE
 LazyData: true
+Imports: htmlwidgets
 Suggests: knitr,
     testthat
 VignetteBuilder: knitr
-Imports: htmlwidgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,10 +16,10 @@ Authors@R: c(
 Maintainer: Kenton Russell <kent.russell@timelyportfolio.com>
 Description: Provides easy access to the dimple d3.js plotting library in the form
                 of an htmlwidget.
-Depends: R (>= 3.1.2)
+Depends: R (>= 3.1.2),
+    htmlwidgets
 License: MIT + file LICENSE
 LazyData: true
-Imports: htmlwidgets
 Suggests: knitr,
     testthat
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,3 +22,4 @@ LazyData: true
 Suggests: knitr,
     testthat
 VignetteBuilder: knitr
+Imports: htmlwidgets


### PR DESCRIPTION
There was a problem deploying to shinyapps.io due to dependencies to htmlwidgets not being fulfilled. Altered the DESCRIPTION file to list dependencies for both htmltools AND htmlwidgets. Not sure if it was necessary to have BOTH as dependencies but it did the trick and now can deploy Shiny application which relies on rcdimple onto shinyapps.io
